### PR TITLE
get-github-readme upgrade: html returned instead of markdoz

### DIFF
--- a/get-github-readme/README.md
+++ b/get-github-readme/README.md
@@ -18,7 +18,7 @@ Example 2: [react-router](https://github.com/rackt/react-router)
 
 ### Relative links
 
-In Github.com README pages, relative links in URL are replaced by absolute links to the resources of the current branch.
+When Github.com renders README pages, relative links in URL are replaced by absolute links to the resources of the current branch.
 
 Example 1: Mostly adequate guide to FP
 
@@ -36,16 +36,22 @@ Example 1: Mostly adequate guide to FP
 
 But when calling Github API, relative links are not replaced, so we have to process the links by ourselves!
 
+Example 2: [Flux](https://github.com/facebook/flux)
+
+### Anchors in async README
+
+TODO
+
 
 ## Check the result in the browser
 
-Launch the Express web server
+STEP 1: launch the Express web server
 
 ```
 babel-node get-github-readme/server
 ```
 
-Check the links and the images in the following links
+STEP 2: check the links and the images in the following pages
 
 * http://localhost:3000/?url=https://github.com/caolan/async
 * http://localhost:3000/?url=https://github.com/node-inspector/node-inspector
@@ -63,7 +69,9 @@ babel-node get-github-readme https://github.com/sindresorhus/awesome
 
 ## micro-service on webtask.io
 
-The "webtask" has been created from Github "raw" code URL
+The "webtask" has been created from Github "raw" code URL.
+
+### `master` branch => production (used by bestofjs.org)
 
 ```
 wt create https://raw.githubusercontent.com/michaelrambeau/microservices/master/get-github-readme/get-github-readme.js  --secret client_id=*** --secret client_secret=*** --secret username=michaelrambeau
@@ -73,4 +81,16 @@ Generated URL:
 
 ```
 https://webtask.it.auth0.com/api/run/wt-***-gmail_com-0/85801138b3a9d89112d0a04eef536d1f?webtask_no_cache=1
+```
+
+### `dev` branch => developpement (local)
+
+```
+wt create https://raw.githubusercontent.com/michaelrambeau/microservices/dev/get-github-readme/get-github-readme.js  --secret client_id=*** --secret client_secret=*** --secret username=michaelrambeau
+```
+
+Generated URL:
+
+```
+https://webtask.it.auth0.com/api/run/wt-mikeair-gmail_com-0/d4bf0bb7021ce02e77d5e2dceac010c7?webtask_no_cache=1
 ```

--- a/get-github-readme/README.md
+++ b/get-github-readme/README.md
@@ -1,8 +1,59 @@
-# "Github ReadMe" micro-service
+# "Get Github README" micro-service
 
 ## Objective
 
-From a given repository URL, return "README.me" content, so that it can be included in any web page.
+From a given repository URL, return "README.md" content in HTML, so that it can be included in any web page.
+
+## The problems
+
+### Links to anchors `<a href="#quickstart">`
+
+Links to anchor have to be replaced by absolute URLs.
+
+Example 1: [node-inspector](https://github.com/node-inspector/node-inspector)
+
+`<a href="#quick-start">Quick Start</a>` => `<a href="https://github.com/node-inspector/node-inspector#quick-start">Quick Start</a>`
+
+Example 2: [react-router](https://github.com/rackt/react-router)
+
+### Relative links
+
+In Github.com README pages, relative links in URL are replaced by absolute links to the resources of the current branch.
+
+Example 1: Mostly adequate guide to FP
+
+[Github API](https://api.github.com/repos/MostlyAdequate/mostly-adequate-guide/readme)
+
+```
+<img src="images/cover.png" alt="cover" style="max-width:100%;">
+```
+
+[README page](https://github.com/MostlyAdequate/mostly-adequate-guide)
+
+```
+<img src="/MostlyAdequate/mostly-adequate-guide/raw/master/images/cover.png" alt="cover" style="max-width:100%;">
+```
+
+But when calling Github API, relative links are not replaced, so we have to process the links by ourselves!
+
+
+## Check the result in the browser
+
+Launch the Express web server
+
+```
+babel-node get-github-readme/server
+```
+
+Check the links and the images in the following links
+
+* http://localhost:3000/?url=https://github.com/caolan/async
+* http://localhost:3000/?url=https://github.com/node-inspector/node-inspector
+* http://localhost:3000/?url=https://github.com/facebook/flux
+* http://localhost:3000/?url=https://github.com/rackt/react-router
+* http://localhost:3000/?url=https://github.com/MostlyAdequate/mostly-adequate-guide
+
+
 
 ## Command line to run the task locally
 

--- a/get-github-readme/get-github-readme.js
+++ b/get-github-readme/get-github-readme.js
@@ -1,110 +1,6 @@
 "use latest";
 const request = require('request');
-
-//Generic function to make a Github request for a given repository
-//Parameters:
-// - repo: full URL of the Github repository
-// - path (optional): added to the repository (ex: '/readme')
-const githubRequest = function(repo, path, options, cb) {
-  const { credentials } = options;
-  let url = repo.replace(/https\:\/\/github.com/, 'https://api.github.com/repos');
-  url = `${url}${path}?client_id=${credentials.client_id}&client_secret=${credentials.client_secret}`;
-  var requestOptions = {
-    url: url,
-    headers: {
-      'User-Agent': credentials.username,
-      'Accept': 'application/vnd.github.VERSION.html'
-    }
-  };
-  console.log('Github request', requestOptions);
-  request.get(requestOptions, function(error, response, body) {
-    if (!error && response.statusCode === 200) {
-      console.log('==> response OK!!!', body.length);
-      return cb(null, body);
-    } else {
-      return cb(new Error("Invalid response from Github for url " + url));
-    }
-  });
-};
-
-
-const getGithubReadme = function(project, options, cb) {
-  githubRequest(project, '/readme', options, function(err, text) {
-    if (err) {
-      return cb(err);
-    } else {
-      return cb(null, text);
-    }
-  });
-};
-
-var getReadMe = function (repo, options, cb) {
-  getGithubReadme(repo, options, function (err, readme) {
-    if (err) return cb(err);
-
-    var root = repo;
-
-    //STEP1: replace relative anchor link URL
-    //[Quick Start](#quick-start) => [Quick Start](https://github.com/node-inspector/node-inspector#quick-start)"
-    readme = readme.replace(/<a href="\#([^"]+)">/gi, function(match, p1) {
-      console.log('Replace link relative anchors', p1);
-      return `<a href="${root}#${p1}">`;
-    });
-    //STEP1.2: replace relative link URL
-    //[Guides and API Docs](/docs) => [Guides and API Docs](https://github.com/rackt/react-router/tree/master/docs)"
-    readme = readme.replace(/<a href="\/(.+?)">/gi, function(match, p1) {
-      console.log('Replace link relative URL', p1);
-      return `<a href="${root}/blob/master/${p1}">`;
-    });
-
-    //markdown images seen on https://github.com/MostlyAdequate/mostly-adequate-guide
-    //![cover](images/cover.png)] => ![cover](https://github.com/MostlyAdequate/mostly-adequate-guide/raw/master/images/cover.png)
-    readme = readme.replace(/\!\[(.+?)\]\(\/(.+?)\)/gi, function(match, p1, p2) {
-      console.log('Replace md image relative URL', p1);
-      return `[${p1}](${root}/blob/master/${p2})`;
-     });
-
-
-
-    //STEP2: replace relative image URL
-    readme = readme.replace(/src=\"(.+?)\"/gi, function(match, p1) {
-      console.log('Replace image relative URL', p1);
-      return 'src="'+ getImagePath(root, p1) + '"';
-    });
-
-    //STEP3 remove self closed anchors (seen on async repo)
-    //the regexp matches: <a name=\"forEach\"> and <a name="forEach">
-    readme = readme.replace(/<a name=\\?"(.+?)\\?" \/>/gi, function(match, p1) {
-      console.log('Remove self closed anchor', p1);
-      return '';
-    });
-    //matches <a name="constant">
-    readme = readme.replace(/<a name="(.+?)">/gi, function(match, p1) {
-      console.log('Remove anchor', p1);
-      return '';
-    });
-
-
-    //data.readme = err ? 'Unable to access README.' : readme;
-    cb(null, readme);
-  });
-};
-
-//Replace relative URL by absolute URL
-function getImagePath (root, url) {
-  var path = url;
-
-  //If the URL is absolute (start with http), we do nothing...
-  if (path.indexOf('http') === 0) return path;
-
-  //Special case: in Faceboox Flux readme, relative URLs start with './'
-  //so we just remove './' from the UL
-  if (path.indexOf('./') === 0) path = path.replace(/.\//, '');
-
-  //...otherwise we create an absolute URL to the "raw image
-  // example: images in "You-Dont-Know-JS" repo.
-  return root + '/raw/master/' + path;
-}
+const DEBUG = false; //use to display console debug messages
 
 /*
 The main function run by the microservice
@@ -142,3 +38,104 @@ module.exports = function (context, done) {
   });
 
 };
+
+//Generic function to make a Github request for a given repository
+//Parameters:
+// - repo: full URL of the Github repository
+// - path (optional): added to the repository (ex: '/readme')
+const githubRequest = function(repo, path, options, cb) {
+  const { credentials } = options;
+  let url = repo.replace(/https\:\/\/github.com/, 'https://api.github.com/repos');
+  url = `${url}${path}?client_id=${credentials.client_id}&client_secret=${credentials.client_secret}`;
+  var requestOptions = {
+    url: url,
+    headers: {
+      'User-Agent': credentials.username,
+      'Accept': 'application/vnd.github.VERSION.html'
+    }
+  };
+  console.log('Github request', requestOptions);
+  request.get(requestOptions, function(error, response, body) {
+    if (!error && response.statusCode === 200) {
+      return cb(null, body);
+    } else {
+      return cb(new Error("Invalid response from Github for url " + url));
+    }
+  });
+};
+
+
+const getGithubReadme = function(project, options, cb) {
+  githubRequest(project, '/readme', options, function(err, text) {
+    if (err) {
+      return cb(err);
+    } else {
+      return cb(null, text);
+    }
+  });
+};
+
+var getReadMe = function (repo, options, cb) {
+  getGithubReadme(repo, options, function (err, readme) {
+    if (err) return cb(err);
+
+    var root = repo;
+
+    //STEP1: replace relative anchor link URL
+    //[Quick Start](#quick-start) => [Quick Start](https://github.com/node-inspector/node-inspector#quick-start)"
+    readme = readme.replace(/<a href="\#([^"]+)">/gi, function(match, p1) {
+      if (DEBUG) console.log('Replace link relative anchors', p1);
+      return `<a href="${root}#${p1}">`;
+    });
+    //STEP2: replace relative link URL
+    //[Guides and API Docs](/docs) => [Guides and API Docs](https://github.com/rackt/react-router/tree/master/docs)"
+    readme = readme.replace(/<a href="\/(.+?)">/gi, function(match, p1) {
+      if (DEBUG) console.log('Replace link relative URL', p1);
+      return `<a href="${root}/blob/master/${p1}">`;
+    });
+
+    //STEP3: markdown images seen on https://github.com/MostlyAdequate/mostly-adequate-guide
+    //![cover](images/cover.png)] => ![cover](https://github.com/MostlyAdequate/mostly-adequate-guide/raw/master/images/cover.png)
+    readme = readme.replace(/\!\[(.+?)\]\(\/(.+?)\)/gi, function(match, p1, p2) {
+      if (DEBUG) console.log('Replace md image relative URL', p1);
+      return `[${p1}](${root}/blob/master/${p2})`;
+     });
+
+
+    //STEP4: replace relative image URL
+    readme = readme.replace(/src=\"(.+?)\"/gi, function(match, p1) {
+      if (DEBUG) console.log('Replace image relative URL', p1);
+      return 'src="'+ getImagePath(root, p1) + '"';
+    });
+
+    //STEP5: remove self closed anchors (seen on async repo)
+    //the regexp matches: <a name=\"forEach\"> and <a name="forEach">
+    readme = readme.replace(/<a name=\\?"(.+?)\\?" \/>/gi, function() {
+      if (DEBUG) console.log('Remove self closed anchor', p1);
+      return '';
+    });
+    //matches <a name="constant">
+    readme = readme.replace(/<a name="(.+?)">/gi, function() {
+      if (DEBUG) console.log('Remove anchor', p1);
+      return '';
+    });
+
+    cb(null, readme);
+  });
+};
+
+//Replace relative URL by absolute URL
+function getImagePath (root, url) {
+  var path = url;
+
+  //If the URL is absolute (start with http), we do nothing...
+  if (path.indexOf('http') === 0) return path;
+
+  //Special case: in Faceboox Flux readme, relative URLs start with './'
+  //so we just remove './' from the UL
+  if (path.indexOf('./') === 0) path = path.replace(/.\//, '');
+
+  //...otherwise we create an absolute URL to the "raw image
+  // example: images in "You-Dont-Know-JS" repo.
+  return root + '/raw/master/' + path;
+}

--- a/get-github-readme/get-github-readme.js
+++ b/get-github-readme/get-github-readme.js
@@ -1,29 +1,26 @@
 "use latest";
 const request = require('request');
-//const async = require('async');
 
-const githubRequest = function(project, path, options, cb) {
+//Generic function to make a Github request for a given repository
+//Parameters:
+// - repo: full URL of the Github repository
+// - path (optional): added to the repository (ex: '/readme')
+const githubRequest = function(repo, path, options, cb) {
   const { credentials } = options;
-  let url = project.repository.replace(/https\:\/\/github.com/, 'https://api.github.com/repos');
+  let url = repo.replace(/https\:\/\/github.com/, 'https://api.github.com/repos');
   url = `${url}${path}?client_id=${credentials.client_id}&client_secret=${credentials.client_secret}`;
   var requestOptions = {
     url: url,
     headers: {
       'User-Agent': credentials.username,
-      'Accept': 'application/vnd.github.quicksilver-preview+json'
+      'Accept': 'application/vnd.github.VERSION.html'
     }
   };
   console.log('Github request', requestOptions);
   request.get(requestOptions, function(error, response, body) {
-    var json;
     if (!error && response.statusCode === 200) {
-      try {
-        json = JSON.parse(body);
-        return cb(null, json);
-      } catch (error1) {
-        error = error1;
-        return cb(new Error("Unable to parse JSON response from Github for url " + url + ": " + error));
-      }
+      console.log('==> response OK!!!', body.length);
+      return cb(null, body);
     } else {
       return cb(new Error("Invalid response from Github for url " + url));
     }
@@ -32,41 +29,50 @@ const githubRequest = function(project, path, options, cb) {
 
 
 const getGithubReadme = function(project, options, cb) {
-  githubRequest(project, '/readme', options, function(err, json) {
-    var buffer, readme;
+  githubRequest(project, '/readme', options, function(err, text) {
     if (err) {
       return cb(err);
     } else {
-      buffer = new Buffer(json.content, 'base64');
-      readme = buffer.toString('utf8');
-      return cb(null, readme);
+      return cb(null, text);
     }
   });
 };
 
-var getReadMe = function (project, options, cb) {
-  getGithubReadme(project, options, function (err, readme) {
+var getReadMe = function (repo, options, cb) {
+  getGithubReadme(repo, options, function (err, readme) {
     if (err) return cb(err);
-    var root = project.repository;
+
+    var root = repo;
 
     //STEP1: replace relative anchor link URL
     //[Quick Start](#quick-start) => [Quick Start](https://github.com/node-inspector/node-inspector#quick-start)"
-    readme = readme.replace(/\]\(\#(.+?)\)/gi, function(match, p1) {
+    readme = readme.replace(/<a href="\#([^"]+)">/gi, function(match, p1) {
       console.log('Replace link relative anchors', p1);
-      return `](${root}#${p1})`;
+      return `<a href="${root}#${p1}">`;
     });
     //STEP1.2: replace relative link URL
     //[Guides and API Docs](/docs) => [Guides and API Docs](https://github.com/rackt/react-router/tree/master/docs)"
-    readme = readme.replace(/\]\(\/(.+?)\)/gi, function(match, p1) {
+    readme = readme.replace(/<a href="\/(.+?)">/gi, function(match, p1) {
       console.log('Replace link relative URL', p1);
-      return `](${root}/blob/master/${p1})`;
+      return `<a href="${root}/blob/master/${p1}">`;
     });
+
+    //markdown images seen on https://github.com/MostlyAdequate/mostly-adequate-guide
+    //![cover](images/cover.png)] => ![cover](https://github.com/MostlyAdequate/mostly-adequate-guide/raw/master/images/cover.png)
+    readme = readme.replace(/\!\[(.+?)\]\(\/(.+?)\)/gi, function(match, p1, p2) {
+      console.log('Replace md image relative URL', p1);
+      return `[${p1}](${root}/blob/master/${p2})`;
+     });
+
+
+
     //STEP2: replace relative image URL
     readme = readme.replace(/src=\"(.+?)\"/gi, function(match, p1) {
       console.log('Replace image relative URL', p1);
       return 'src="'+ getImagePath(root, p1) + '"';
     });
-    //STEP3 remove self closed anchors
+
+    //STEP3 remove self closed anchors (seen on async repo)
     //the regexp matches: <a name=\"forEach\"> and <a name="forEach">
     readme = readme.replace(/<a name=\\?"(.+?)\\?" \/>/gi, function(match, p1) {
       console.log('Remove self closed anchor', p1);
@@ -124,13 +130,10 @@ module.exports = function (context, done) {
   if (!credentials.client_id) return sendError('No Github credentials `client_id`');
   if (!credentials.client_secret) return sendError('No Github credentials `client_secret`');
 
-  const project = {
-    repository: url
-  };
   const options = {
     credentials
   };
-  getReadMe(project, options, function (err, readme) {
+  getReadMe(url, options, function (err, readme) {
     if (err) console.log(err);
     var result = {
       readme: readme

--- a/get-github-readme/index.js
+++ b/get-github-readme/index.js
@@ -13,6 +13,8 @@ const context = {
 
 const t0 = process.hrtime();
 
+console.log('Starting manually the webtask', context.data);
+
 webtask(context, function(err, result) {
   if (err) {
     return console.log(err);

--- a/get-github-readme/server.js
+++ b/get-github-readme/server.js
@@ -1,0 +1,36 @@
+require('dotenv').load();
+const PORT = 3000;
+
+const webtask = require('./get-github-readme');
+const context = {
+  data: {
+    username: process.env.GITHUB_USERNAME,
+    client_id: process.env.GITHUB_CLIENT_ID,
+    client_secret: process.env.GITHUB_CLIENT_SECRET
+  }
+};
+
+const Express = require('express');
+const app = Express();
+
+app.get('/', function (req, res) {
+  console.log('query', req.query);
+  const url = req.query.url;
+  if (!url) return res.status(500).json({ error: 'Specify the `?url=` querystring paramter' });
+  context.data.url = url;
+  console.log('Starting the webtask', context.data);
+  webtask(context, function(err, result) {
+    if (err) {
+      console.log(err);
+      res.status(500).json({ error: err.message });
+    } else {
+      const html = result.readme;
+      console.log('README length', html.length);
+      res.send(html);
+    }
+  });
+});
+
+
+console.log('Express server listening on port', PORT);
+app.listen(PORT);

--- a/get-github-readme/spec.js
+++ b/get-github-readme/spec.js
@@ -6,7 +6,8 @@ const urls = [
   'https://github.com/caolan/async',
   'https://github.com/node-inspector/node-inspector',
   'https://github.com/facebook/flux',
-  'https://github.com/rackt/react-router'
+  'https://github.com/rackt/react-router',
+  'https://github.com/MostlyAdequate/mostly-adequate-guide'
 ];
 urls.forEach( url => getReadme(url) );
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "async": "^1.4.2",
     "cheerio": "^0.19.0",
     "dotenv": "^1.2.0",
+    "express": "^4.13.3",
     "minimist": "^1.2.0",
     "moment": "^2.10.6",
     "request": "^2.61.0"


### PR DESCRIPTION
webui now gets html content from the microservice, instead of html previously.`marked` is no more needed by the web ui.
